### PR TITLE
chore: move gulp npm package to devDependencies

### DIFF
--- a/packages/eslint-plugin-angular-template/package.json
+++ b/packages/eslint-plugin-angular-template/package.json
@@ -29,14 +29,13 @@
     },
     "dependencies": {
         "@angular-eslint/eslint-plugin-template": "^12.0.0",
-        "@types/ncp": "^2.0.4",
         "@typescript-eslint/experimental-utils": "^4.24.0",
-        "gulp": "^4.0.2",
         "tslint": "^5.11.0",
         "tslint-eslint-rules": "^5.4.0"
     },
     "devDependencies": {
         "@types/gulp": "^4.0.5",
+        "@types/ncp": "^2.0.4",
         "@types/rimraf": "^3.0.0",
         "@types/run-sequence": "0.0.30",
         "gulp-modify-file": "^1.0.1",
@@ -46,7 +45,8 @@
         "run-sequence": "^2.2.1",
         "standard-changelog": "^2.0.6",
         "ts-node": "^7.0.1",
-        "typescript": "^3.1.6"
+        "typescript": "^3.1.6",
+        "gulp": "^4.0.2"
     },
     "peerDependencies": {
         "eslint": "*",

--- a/packages/eslint-plugin-angular/package.json
+++ b/packages/eslint-plugin-angular/package.json
@@ -29,14 +29,13 @@
     },
     "dependencies": {
         "@angular-eslint/eslint-plugin-template": "^12.0.0",
-        "@types/ncp": "^2.0.4",
         "@typescript-eslint/experimental-utils": "^4.24.0",
-        "gulp": "^4.0.2",
         "tslint": "^5.11.0",
         "tslint-eslint-rules": "^5.4.0"
     },
     "devDependencies": {
         "@types/gulp": "^4.0.5",
+        "@types/ncp": "^2.0.4",
         "@types/rimraf": "^3.0.0",
         "@types/run-sequence": "0.0.30",
         "gulp-modify-file": "^1.0.1",
@@ -46,7 +45,8 @@
         "run-sequence": "^2.2.1",
         "standard-changelog": "^2.0.6",
         "ts-node": "^7.0.1",
-        "typescript": "^3.1.6"
+        "typescript": "^3.1.6",
+        "gulp": "^4.0.2"
     },
     "peerDependencies": {
         "eslint": "*",


### PR DESCRIPTION
Just moving the gulp dependencies from **dependencies** to **devDependencies"

Fix for #15 