### PR TITLE
fix-switch-case-spacing

### DIFF
--- a/packages/eslint-plugin/src/configs/recommended.json
+++ b/packages/eslint-plugin/src/configs/recommended.json
@@ -48,7 +48,8 @@
                 },
                 "FunctionExpression": {
                     "parameters": "first"
-                }
+                },
+                "SwitchCase": 1
             }
         ],
         "@typescript-eslint/member-delimiter-style": [


### PR DESCRIPTION
fixes odd tabbing in switch cases

before:
![image](https://user-images.githubusercontent.com/7864125/228951366-b1c227f6-4b7a-412e-8e0e-03ea73717978.png)

after:
![image](https://user-images.githubusercontent.com/7864125/228951434-de56775f-05f2-4f66-8909-1d94d4a54194.png)
