### PR TITLE
fix: explicitly do not require a selector prefix on directives

### DIFF
--- a/.changeset/directive-selector-no-prefix.md
+++ b/.changeset/directive-selector-no-prefix.md
@@ -1,0 +1,9 @@
+---
+"@tylertech-eslint/eslint-plugin-angular": patch
+---
+
+Fix `recommended` config: `@angular-eslint/directive-selector` now explicitly sets `prefix: []`, matching `@angular-eslint/component-selector`.
+
+Previously the rule had no `prefix` option, so it silently inherited whatever default `angular-eslint`'s own `directive-selector` rule shipped with. That default was `''` (no requirement) on `angular-eslint` v20, but changed to `'app'` on v21+. Since this plugin's `angular-eslint` peer dependency range includes v21/v22, consumers who upgraded picked up a new, unintended `directive-selector` error requiring an `app` prefix on every `@Directive` selector, even in codebases with no such naming convention (e.g. `angular.json`'s `prefix: ""`).
+
+This fix restores the intended behavior: the `recommended` config does not require any directive selector prefix unless a consumer opts in by overriding the rule. This is a bug fix, not a behavior tightening — it can only make previously-flagged directive selectors pass, never the reverse.

--- a/packages/eslint-plugin-angular/src/configs/recommended.ts
+++ b/packages/eslint-plugin-angular/src/configs/recommended.ts
@@ -26,6 +26,7 @@ const config: FlatConfig.ConfigArray = [
         'error',
         {
           type: 'attribute',
+          prefix: [],
           style: 'camelCase',
         },
       ],

--- a/packages/eslint-plugin-angular/src/configs/test/configs.test.ts
+++ b/packages/eslint-plugin-angular/src/configs/test/configs.test.ts
@@ -29,6 +29,26 @@ describe('recommended (TypeScript) config', () => {
       messages.some(m => m.ruleId === '@angular-eslint/component-class-suffix'),
     ).toBe(true);
   });
+
+  it('does not require an "app" prefix on directive selectors', () => {
+    const linter = new Linter();
+    const directive = [
+      "import { Directive } from '@angular/core';",
+      '@Directive({ selector: "[tylFoo]" })',
+      'export class FooDirective {}',
+    ].join('\n');
+
+    const config = [{ files: ['**/*.ts'] }, ...recommended] as Linter.Config[];
+    const messages = linter.verify(directive, config, 'foo.directive.ts');
+
+    expect(messages.some(m => m.fatal)).toBe(false);
+    // Regression guard: `directive-selector` must explicitly set `prefix: []`
+    // so it doesn't silently inherit angular-eslint's own default prefix
+    // (which changed from '' to 'app' between angular-eslint v20 and v21).
+    expect(
+      messages.some(m => m.ruleId === '@angular-eslint/directive-selector'),
+    ).toBe(false);
+  });
 });
 
 describe('templateRecommended (HTML) config', () => {


### PR DESCRIPTION
angular-eslint versions <=20 did not set a default directive prefix and our config simply fell through to angular-eslint's default

Now, angular-eslint versions >21 set the default to "app". So since our config did not explicitly override that prefix all directives are required to be prefixed with "app" which was never intended.

This PR adds our own empty override which ensures that directives do not need a prefix (what was always intended)